### PR TITLE
[update] anyhowクレートを使用したエラーハンドリング

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +687,7 @@ dependencies = [
 name = "raxtest"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 clap = { version = "4.2.1", features = ["derive"] }
 regex = "1.7.3"
 reqwest = { version = "0.11.16", features = ["json", "blocking"] }
-serde = {version = "1.0.159", features = ["derive"] }
+serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 serde_yaml = "0.9.19"
 tokio = { version = "1.27.0", features = ["full"] }
+anyhow = "1.0.70"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod utils;
+use utils::types::RaxResult;
 use utils::{gen_struct, render_results, run_init, run_test};
 
 use clap::Parser;
@@ -17,7 +18,7 @@ struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> RaxResult<()> {
     let args = Args::parse();
 
     let ascii_art = r#"

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinHandle;
 
 use serde_json::{to_string_pretty, to_writer_pretty, Value};
 
-use anyhow::bail;
+use anyhow::anyhow;
 
 // とりあえず, mainから呼べるようにpubをつけている. いい方法かは不明
 pub mod types;
@@ -27,9 +27,14 @@ pub fn gen_struct(index_path: String) -> RaxResult<(TestConfig, JsonMap)> {
 
     // データファイルのパス指定が正しいかチェックする
     println!("[* ] Checking data file path...");
+
     if !test_config.data.starts_with("json://") {
-        bail!("Invalid data file path");
+        return Err(anyhow!("Invalid data file path"));
+        // anyhowマクロで簡単にanyuhowのエラーを返せる
+        // bail!(hoge) という書き方もある
         // bail!(hoge) は return Err(anyhow!(hoge)) と同じ意味;
+        // ensureマクロを使うとifを使わずに書ける
+        // ensure!(test_config.data.starts_with("json://"),"Invalid data file path");
     }
 
     // データの格納されているjsonファイルを読み込む

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,13 +8,17 @@ use tokio::task::JoinHandle;
 
 use serde_json::{to_string_pretty, to_writer_pretty, Value};
 
-mod types;
-use types::{InitStep, JsonMap, ResultData, TestConfig, TestStep};
+use anyhow::bail;
+
+// とりあえず, mainから呼べるようにpubをつけている. いい方法かは不明
+pub mod types;
+
+use types::{InitStep, JsonMap, RaxResult, ResultData, TestConfig, TestStep};
 
 use self::types::TestResult;
 
 // テスト構成ファイルの構造体を生成する関数
-pub fn gen_struct(index_path: String) -> Result<(TestConfig, JsonMap), Box<dyn std::error::Error>> {
+pub fn gen_struct(index_path: String) -> RaxResult<(TestConfig, JsonMap)> {
     // テスト構成ファイルを読み込む
     println!("[* ] Loading test config file...");
     let config_file = File::open(&index_path)?;
@@ -24,7 +28,8 @@ pub fn gen_struct(index_path: String) -> Result<(TestConfig, JsonMap), Box<dyn s
     // データファイルのパス指定が正しいかチェックする
     println!("[* ] Checking data file path...");
     if !test_config.data.starts_with("json://") {
-        return Err("Invalid data file path".into());
+        bail!("Invalid data file path");
+        // bail!(hoge) は return Err(anyhow!(hoge)) と同じ意味;
     }
 
     // データの格納されているjsonファイルを読み込む
@@ -45,7 +50,7 @@ pub async fn run_init(
     base_url: &String,
     init: Vec<InitStep>,
     json_data: &JsonMap,
-) -> Result<HashMap<String, String>, Box<dyn std::error::Error>> {
+) -> RaxResult<HashMap<String, String>> {
     // クッキーを格納するハッシュマップを作成
     let mut cookie_map: HashMap<String, String> =
         init.iter().fold(HashMap::new(), |mut acc, key| {
@@ -117,7 +122,7 @@ pub async fn run_test(
     steps: Vec<TestStep>,
     json_data: &JsonMap,
     cookie_map: &HashMap<String, String>,
-) -> Result<Vec<TestResult>, Box<dyn std::error::Error>> {
+) -> RaxResult<Vec<TestResult>> {
     // HTTPクライアントを初期化
     let client = Client::new();
 
@@ -263,7 +268,7 @@ pub fn render_results(
     base_url: &String,
     output_json_path: &String,
     results: Vec<TestResult>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> RaxResult<()> {
     // 書き出すJSONデータを作成する
     let result_data = ResultData {
         base_url: base_url.clone(),

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,3 +1,4 @@
+use anyhow::Error;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -50,3 +51,7 @@ pub struct ResultData {
 // Jsonの内容を格納する連想配列を定義する
 // 引数：String -> jsonのキー。所有権を移動する
 pub type JsonMap = HashMap<String, HashMap<String, HashMap<String, Value>>>;
+
+// anyhowを使用したResult型のエイリアス
+// 名前は適当につけているので、好きな名前に変更しても良い
+pub type RaxResult<T> = Result<T, Error>;

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -54,4 +54,5 @@ pub type JsonMap = HashMap<String, HashMap<String, HashMap<String, Value>>>;
 
 // anyhowを使用したResult型のエイリアス
 // 名前は適当につけているので、好きな名前に変更しても良い
+// anyhow::Result<T> は Result<T, anyhow::Error> と同じ意味なので，そっちのほうが良いかも
 pub type RaxResult<T> = Result<T, Error>;


### PR DESCRIPTION
anyhowクレートを使用することにより，今後複数種類のエラーを簡単にまとめることが可能になる
typesに独自のResult型のエイリアスを定義することで，簡単にResultを返せるようになる(いちいち box<dyn E> と書かなくてよくなる)